### PR TITLE
Update log message and fix child process launch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.0.0</Version>
+        <Version>1.0.0.2</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -108,6 +108,7 @@ public class FileAndDirectoryDeleter
 		{
 			try
 			{
+				directory.Attributes &= ~FileAttributes.ReadOnly;
 				directory.Delete();
 				break;
 			}

--- a/ForceOps.Lib/src/ForceOpsContext/ForceOpsContext.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/ForceOpsContext.cs
@@ -2,7 +2,17 @@
 
 public class ForceOpsContext
 {
-	public int maxAttempts = 5;
+	/// <summary>
+	/// The number of retries when performing an operation.
+	/// For example, five retries equals six total attempts.
+	/// </summary>
+	public int maxRetries = 5;
+
+	/// <summary>
+	/// The time to wait between before retrying the operation.
+	/// </summary>
+	public TimeSpan retryDelay = TimeSpan.FromMilliseconds(500);
+
 	public IProcessKiller processKiller;
 	public IElevateUtils elevateUtils;
 	public IRelaunchAsElevated relaunchAsElevated;

--- a/ForceOps.Lib/src/ForceOpsContext/ProcessKiller.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/ProcessKiller.cs
@@ -8,9 +8,11 @@ internal class ProcessKiller : IProcessKiller
 	public void KillProcesses(IEnumerable<ProcessInfo?> processes)
 	{
 		var runningProcesses = new List<Process>();
+		var currentProcess = Process.GetCurrentProcess();
 		foreach (var process in processes)
 		{
 			if (process == null) continue;
+			if (currentProcess?.Id == process.ProcessId) continue;
 			try
 			{
 				runningProcesses.Add(Process.GetProcessById(process.ProcessId));

--- a/ForceOps.Test/src/ForceOpsMethodsTest.cs
+++ b/ForceOps.Test/src/ForceOpsMethodsTest.cs
@@ -16,17 +16,17 @@ public class ForceOpsMethodsTest : IDisposable
 	{
 		using var launchedProcess = LaunchProcessInDirectory(tempFolderPath);
 
-		forceOpsContext.maxAttempts = 1;
+		forceOpsContext.maxRetries = 0;
 		var exceptionWithNoRetries = Record.Exception(() => fileAndDirectoryDeleter.DeleteDirectory(new DirectoryInfo(tempFolderPath)));
 		Assert.IsType<IOException>(exceptionWithNoRetries);
 		Assert.StartsWith("The process cannot access the file", exceptionWithNoRetries.Message);
 
-		forceOpsContext.maxAttempts = 5;
+		forceOpsContext.maxRetries = 5;
 		var exceptionWithDirectoryStrategy = Record.Exception(() => fileAndDirectoryDeleter.DeleteDirectory(new DirectoryInfo(tempFolderPath)));
 		Assert.True(null == exceptionWithDirectoryStrategy, testContext.fakeLoggerFactory.GetAllLogsString());
 
-		Assert.Matches(@"DeleteDirectory failed attempt 1/1 for \[.*\]. ForceOps process is not elevated. No attempts remain, so the exception will be thrown.
-DeleteDirectory failed attempt 1/5 for \[.*\]. ForceOps process is not elevated. Found 1 process to try to kill: \[\d+ \- powershell.exe\]", testContext.fakeLoggerFactory.GetAllLogsString());
+		Assert.Matches(@"Exceeded retry count of 0. Failed. ForceOps process is not elevated.
+Could not delete directory .*. Beginning retry 1/5 in 500ms. ForceOps process is not elevated. Found 1 process to try to kill: \[\d+ \- powershell.exe\]", testContext.fakeLoggerFactory.GetAllLogsString());
 	}
 
 	[Fact]
@@ -35,17 +35,17 @@ DeleteDirectory failed attempt 1/5 for \[.*\]. ForceOps process is not elevated.
 		var tempFilePath = GetTemporaryFileName();
 		using var launchedProcess = HoldLockOnFileUsingPowershell(tempFilePath);
 
-		forceOpsContext.maxAttempts = 1;
+		forceOpsContext.maxRetries = 0;
 		var exceptionWithNoRetries = Record.Exception(() => fileAndDirectoryDeleter.DeleteFile(new FileInfo(tempFilePath)));
 		Assert.IsType<IOException>(exceptionWithNoRetries);
 		Assert.StartsWith("The process cannot access the file", exceptionWithNoRetries.Message);
 
-		forceOpsContext.maxAttempts = 5;
+		forceOpsContext.maxRetries = 5;
 		var exceptionWithDirectoryStrategy = Record.Exception(() => fileAndDirectoryDeleter.DeleteFile(new FileInfo(tempFilePath)));
 		Assert.True(null == exceptionWithDirectoryStrategy, testContext.fakeLoggerFactory.GetAllLogsString());
 
-		Assert.Matches($@"DeleteFile failed attempt 1/1 for \[.*\]. ForceOps process is not elevated. No attempts remain, so the exception will be thrown.
-DeleteFile failed attempt 1/5 for \[.*\]. ForceOps process is not elevated. Found 1 process to try to kill: \[\d+ \- powershell.exe\]", testContext.fakeLoggerFactory.GetAllLogsString());
+		Assert.Matches($@"Exceeded retry count of 0. Failed. ForceOps process is not elevated.
+Could not delete file .*. Beginning retry 1/5 in 500ms. ForceOps process is not elevated. Found 1 process to try to kill: \[\d+ \- powershell.exe\]", testContext.fakeLoggerFactory.GetAllLogsString());
 	}
 
 	public ForceOpsMethodsTest()

--- a/ForceOps.Test/src/TestContext.cs
+++ b/ForceOps.Test/src/TestContext.cs
@@ -16,6 +16,7 @@ public class TestContext
 		elevateUtilsMock = new Mock<IElevateUtils>();
 		elevateUtilsMock.Setup(t => t.IsProcessElevated()).Returns(false);
 		relaunchAsElevatedMock = new Mock<IRelaunchAsElevated>();
+		relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated()).Returns(1);
 		fakeLoggerFactory = new FakeLoggerFactory();
 
 		forceOpsContext = new ForceOpsContext(elevateUtils: elevateUtilsMock.Object, loggerFactory: fakeLoggerFactory, relaunchAsElevated: relaunchAsElevatedMock.Object);

--- a/ForceOps/src/Program.cs
+++ b/ForceOps/src/Program.cs
@@ -51,13 +51,16 @@ public class Program
 		}
 		catch (Exception ex) when ((ex is IOException || ex is UnauthorizedAccessException) && !forceOpsContext.elevateUtils.IsProcessElevated())
 		{
-			logger.Information("Received IOException or UnauthorizedAccessException when trying to get process using file or directory. Retrying as elevated.");
+			logger.Information("Unable to perform operation as an unelevated process. Retrying as elevated.");
 			var childProcessExitCode = forceOpsContext.relaunchAsElevated.RelaunchAsElevated();
-			var childResultMessage = childProcessExitCode == 0
-				? "Successfully deleted as admin"
-				: $"Failed with exit code {childProcessExitCode}";
-			logger.Information(childResultMessage);
-			throw new AggregateException($"Child process failed with {childProcessExitCode}. See inner exception for the previous exception.", ex);
+			if (childProcessExitCode != 0)
+			{
+				logger.Information($"Failed with exit code {childProcessExitCode}");
+				throw new AggregateException($"Child process failed with {childProcessExitCode}. See inner exception for the previous exception.", ex);
+			} else
+			{
+				logger.Information("Successfully deleted as admin");
+			}
 		}
 	}
 }

--- a/ForceOps/src/Program.cs
+++ b/ForceOps/src/Program.cs
@@ -57,7 +57,8 @@ public class Program
 			{
 				logger.Information($"Failed with exit code {childProcessExitCode}");
 				throw new AggregateException($"Child process failed with {childProcessExitCode}. See inner exception for the previous exception.", ex);
-			} else
+			}
+			else
 			{
 				logger.Information("Successfully deleted as admin");
 			}


### PR DESCRIPTION
* Update log messages to closer match MSBuild
* Fix incorrect exception being thrown when relaunching as elevated works
* Prevent killing own process
* Fix deleting of read-only directories