### PR TITLE
Improve performance by ~30% by reducing calls to win32 api

### DIFF
--- a/ForceOps.Lib/src/DirectoryUtils.cs
+++ b/ForceOps.Lib/src/DirectoryUtils.cs
@@ -12,6 +12,6 @@ public static class DirectoryUtils
 
 	public static bool IsSymLink(DirectoryInfo folder)
 	{
-		return (folder.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+		return (folder.Attributes & FileAttributes.ReparsePoint) != 0;
 	}
 }

--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -46,7 +46,7 @@ public class FileAndDirectoryDeleter
 		{
 			try
 			{
-				file.IsReadOnly = false;
+				if ((file.Attributes & FileAttributes.ReadOnly) != 0) file.Attributes &= ~FileAttributes.ReadOnly;
 				file.Delete();
 				break;
 			}
@@ -109,7 +109,7 @@ public class FileAndDirectoryDeleter
 		{
 			try
 			{
-				directory.Attributes &= ~FileAttributes.ReadOnly;
+				if ((directory.Attributes & FileAttributes.ReadOnly) != 0) directory.Attributes &= ~FileAttributes.ReadOnly;
 				directory.Delete();
 				break;
 			}
@@ -125,13 +125,16 @@ public class FileAndDirectoryDeleter
 
 	void DeleteFilesInFolder(DirectoryInfo directory)
 	{
-		foreach (var file in directory.GetFiles())
+		foreach (var fileOrDirectory in directory.GetFileSystemInfos())
 		{
-			DeleteFile(file);
-		}
-		foreach (var subDirectory in directory.GetDirectories())
-		{
-			DeleteDirectory(subDirectory);
+			if (fileOrDirectory is FileInfo file)
+			{
+				DeleteFile(file);
+			}
+			else if (fileOrDirectory is DirectoryInfo subDirectory)
+			{
+				DeleteDirectory(subDirectory);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
* `IsInsideDirectory: False`: 27.3% faster: 79.6ms --> 57.84ms
* `IsInsideDirectory: True `:  34.5% faster: 208.01ms --> 136.17ms

## Before (1.0.3)

|                               Method | NumFiles | FileSize | IsInsideDirectory |      Mean |    Error |   StdDev |
|------------------------------------- |--------- |--------- |------------------ |----------:|---------:|---------:|
| **ForceOps.Lib.FileAndDirectoryDeleter** |     **1000** |       **10** |             **False** |  **79.60 ms** | **1.573 ms** | **3.485 ms** |
|           System.IO.Directory.Delete |     1000 |       10 |             False |  60.59 ms | 1.205 ms | 2.569 ms |
| **ForceOps.Lib.FileAndDirectoryDeleter** |     **1000** |       **10** |              **True** | **208.01 ms** | **4.111 ms** | **6.400 ms** |
|           System.IO.Directory.Delete |     1000 |       10 |              True | 139.70 ms | 2.541 ms | 3.392 ms |

## After

|                               Method | NumFiles | FileSize | IsInsideDirectory |      Mean |    Error |   StdDev |
|------------------------------------- |--------- |--------- |------------------ |----------:|---------:|---------:|
| **ForceOps.Lib.FileAndDirectoryDeleter** |     **1000** |       **10** |             **False** |  **57.84 ms** | **1.009 ms** | **1.276 ms** |
|           System.IO.Directory.Delete |     1000 |       10 |             False |  57.38 ms | 1.106 ms | 1.398 ms |
| **ForceOps.Lib.FileAndDirectoryDeleter** |     **1000** |       **10** |              **True** | **136.20 ms** | **2.203 ms** | **1.953 ms** |
|           System.IO.Directory.Delete |     1000 |       10 |              True | 136.17 ms | 2.650 ms | 2.349 ms |