### PR TITLE
Bugfix/delete nonexisting file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.0.4</Version>
+        <Version>1.1.0</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,8 +12,8 @@
 
         <TargetFramework>net7.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
-		<LangVersion>latest</LangVersion>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,11 @@
         <Authors>Dom Slee</Authors>
         <PackageTags>lock file directory force delete</PackageTags>
         <PackageReleaseNotes>https://github.com/domsleee/forceops/blob/main/CHANGELOG.md</PackageReleaseNotes>
+
+        <TargetFramework>net7.0</TargetFramework>
+        <RollForward>LatestMajor</RollForward>
+		<LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
     </PropertyGroup>
 </Project>

--- a/ForceOps.Benchmarks/ForceOps.Benchmarks.csproj
+++ b/ForceOps.Benchmarks/ForceOps.Benchmarks.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<RollForward>LatestMajor</RollForward>
-		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
+++ b/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
@@ -37,7 +37,7 @@ public class FileAndDirectoryDeleterBenchmark
 	[Benchmark(Description = "ForceOps.Lib.FileAndDirectoryDeleter")]
 	public void Deleter()
 	{
-		fileAndDirectoryDeleter.DeleteFileOrDirectory(tempDirectory);
+		fileAndDirectoryDeleter.DeleteFileOrDirectory(tempDirectory, true);
 	}
 
 	[Benchmark(Description = "System.IO.Directory.Delete")]

--- a/ForceOps.Lib/ForceOps.Lib.csproj
+++ b/ForceOps.Lib/ForceOps.Lib.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageOutputPath>./nupkg</PackageOutputPath>

--- a/ForceOps.Lib/src/DirectoryUtils.cs
+++ b/ForceOps.Lib/src/DirectoryUtils.cs
@@ -14,4 +14,12 @@ public static class DirectoryUtils
 	{
 		return (folder.Attributes & FileAttributes.ReparsePoint) != 0;
 	}
+
+	public static void MarkAsNotReadOnly(FileSystemInfo fileSystemInfo)
+	{
+		if ((fileSystemInfo.Attributes & FileAttributes.ReadOnly) != 0)
+		{
+			fileSystemInfo.Attributes &= ~FileAttributes.ReadOnly;
+		}
+	}
 }

--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -22,7 +22,7 @@ public class FileAndDirectoryDeleter
 	/// If the delete fails, it will attempt to find processes using the file or directory
 	/// </summary>
 	/// <param name="fileOrDirectory">File or directory to delete.</param>
-	public void DeleteFileOrDirectory(string fileOrDirectory)
+	public void DeleteFileOrDirectory(string fileOrDirectory, bool force)
 	{
 		fileOrDirectory = CombineWithCWDAndGetAbsolutePath(fileOrDirectory);
 		if (File.Exists(fileOrDirectory))
@@ -35,9 +35,11 @@ public class FileAndDirectoryDeleter
 			DeleteDirectory(new DirectoryInfo(fileOrDirectory));
 			return;
 		}
-		// if the file/folder doesn't exist, it has already been deleted
-		logger.Debug($"{fileOrDirectory} already deleted.");
-		return;
+
+		if (!force)
+		{
+			throw new FileNotFoundException(fileOrDirectory);
+		}
 	}
 
 	internal void DeleteFile(FileInfo file)

--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -46,7 +46,7 @@ public class FileAndDirectoryDeleter
 		{
 			try
 			{
-				if ((file.Attributes & FileAttributes.ReadOnly) != 0) file.Attributes &= ~FileAttributes.ReadOnly;
+				MarkAsNotReadOnly(file);
 				file.Delete();
 				break;
 			}
@@ -109,7 +109,7 @@ public class FileAndDirectoryDeleter
 		{
 			try
 			{
-				if ((directory.Attributes & FileAttributes.ReadOnly) != 0) directory.Attributes &= ~FileAttributes.ReadOnly;
+				MarkAsNotReadOnly(directory);
 				directory.Delete();
 				break;
 			}

--- a/ForceOps.Lib/src/ForceOpsContext/EnvironmentExit.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/EnvironmentExit.cs
@@ -1,0 +1,18 @@
+﻿namespace ForceOps.Lib;
+
+class EnvironmentExit : IEnvironmentExit
+{
+	public void Exit(int exitCode, string message)
+	{
+		WriteErrorLine(message);
+		Environment.Exit(exitCode);
+	}
+
+	static void WriteErrorLine(string message)
+	{
+		var currentColor = Console.ForegroundColor;
+		Console.ForegroundColor = ConsoleColor.Red;
+		Console.WriteLine(message);
+		Console.ForegroundColor = currentColor;
+	}
+}

--- a/ForceOps.Lib/src/ForceOpsContext/ForceOpsContext.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/ForceOpsContext.cs
@@ -17,17 +17,20 @@ public class ForceOpsContext
 	public IElevateUtils elevateUtils;
 	public IRelaunchAsElevated relaunchAsElevated;
 	public ILoggerFactory loggerFactory;
+	public IEnvironmentExit environmentExit;
 
 	public ForceOpsContext(
 		IProcessKiller? processKiller = null,
 		IElevateUtils? elevateUtils = null,
 		IRelaunchAsElevated? relaunchAsElevated = null,
-		ILoggerFactory? loggerFactory = null
+		ILoggerFactory? loggerFactory = null,
+		IEnvironmentExit? environmentExit = null
 	)
 	{
 		this.processKiller = processKiller ?? new ProcessKiller();
 		this.elevateUtils = elevateUtils ?? new ElevateUtils();
 		this.relaunchAsElevated = relaunchAsElevated ?? new RelaunchAsElevated();
 		this.loggerFactory = loggerFactory ?? new LoggerFactory();
+		this.environmentExit = environmentExit ?? new EnvironmentExit();
 	}
 }

--- a/ForceOps.Lib/src/ForceOpsContext/IEnvironmentExit.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/IEnvironmentExit.cs
@@ -1,0 +1,6 @@
+﻿namespace ForceOps.Lib;
+
+public interface IEnvironmentExit
+{
+	void Exit(int exitCode, string message);
+}

--- a/ForceOps.Lib/src/ForceOpsContext/IRelaunchAsElevated.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/IRelaunchAsElevated.cs
@@ -2,5 +2,5 @@ namespace ForceOps.Lib;
 
 public interface IRelaunchAsElevated
 {
-	int RelaunchAsElevated();
+	int RelaunchAsElevated(List<string>? argListOverride = null);
 }

--- a/ForceOps.Lib/src/ForceOpsContext/IRelaunchAsElevated.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/IRelaunchAsElevated.cs
@@ -2,5 +2,5 @@ namespace ForceOps.Lib;
 
 public interface IRelaunchAsElevated
 {
-	int RelaunchAsElevated(List<string>? argListOverride = null);
+	int RelaunchAsElevated(List<string> argListOverride);
 }

--- a/ForceOps.Lib/src/ForceOpsContext/RelaunchAsElevated.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/RelaunchAsElevated.cs
@@ -1,36 +1,48 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace ForceOps.Lib;
 
 public class RelaunchAsElevated : IRelaunchAsElevated
 {
-	int IRelaunchAsElevated.RelaunchAsElevated()
+	internal string verb = "runas";
+	internal string? exeNameOverride = null;
+
+	int IRelaunchAsElevated.RelaunchAsElevated(List<string>? argListOverride)
 	{
-		var exeName = Environment.ProcessPath;
+		var exeName = exeNameOverride ?? Environment.ProcessPath;
 		var startInfo = new ProcessStartInfo(exeName!)
 		{
-			//RedirectStandardInput = true,
-			//RedirectStandardOutput = true,
 			UseShellExecute = true,
 			WorkingDirectory = Environment.CurrentDirectory,
-			Verb = "runas",
-			//WindowStyle = ProcessWindowStyle.Hidden
+			Verb = verb,
 		};
-		foreach (var arg in Environment.GetCommandLineArgs().Skip(1))
+
+		if (argListOverride != null)
 		{
-			startInfo.ArgumentList.Add(arg);
+			AddRange(startInfo.ArgumentList, argListOverride);
 		}
-		startInfo.Verb = "runas";
+		else
+		{
+			AddRange(startInfo.ArgumentList, Environment.GetCommandLineArgs().Skip(1));
+		}
+
 		var process = new Process() { StartInfo = startInfo };
 
 		process.OutputDataReceived += (sender, e) => Console.WriteLine(e.Data);
 		process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine(e.Data);
 
 		process.Start();
-		//process.BeginOutputReadLine();
-		//process.BeginErrorReadLine();
 		process.WaitForExit();
 
 		return process.ExitCode;
+	}
+
+	static void AddRange(Collection<string> argList, IEnumerable<string> argsToAdd)
+	{
+		foreach (var arg in argsToAdd)
+		{
+			argList.Add(arg);
+		}
 	}
 }

--- a/ForceOps.Lib/src/ForceOpsContext/RelaunchAsElevated.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/RelaunchAsElevated.cs
@@ -8,7 +8,7 @@ public class RelaunchAsElevated : IRelaunchAsElevated
 	internal string verb = "runas";
 	internal string? exeNameOverride = null;
 
-	int IRelaunchAsElevated.RelaunchAsElevated(List<string>? argListOverride)
+	int IRelaunchAsElevated.RelaunchAsElevated(List<string> argumentList)
 	{
 		var exeName = exeNameOverride ?? Environment.ProcessPath;
 		var startInfo = new ProcessStartInfo(exeName!)
@@ -18,14 +18,7 @@ public class RelaunchAsElevated : IRelaunchAsElevated
 			Verb = verb,
 		};
 
-		if (argListOverride != null)
-		{
-			AddRange(startInfo.ArgumentList, argListOverride);
-		}
-		else
-		{
-			AddRange(startInfo.ArgumentList, Environment.GetCommandLineArgs().Skip(1));
-		}
+		AddRange(startInfo.ArgumentList, argumentList);
 
 		var process = new Process() { StartInfo = startInfo };
 

--- a/ForceOps.Test/ForceOps.Test.csproj
+++ b/ForceOps.Test/ForceOps.Test.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/ForceOps.Test/src/ProgramTest.cs
+++ b/ForceOps.Test/src/ProgramTest.cs
@@ -53,7 +53,7 @@ public sealed class ProgramTest : IDisposable
 		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>?>()), Times.Never());
 	}
 
-	
+
 	[Fact]
 	public void RelaunchedProgramWorks()
 	{

--- a/ForceOps.Test/src/ProgramTest.cs
+++ b/ForceOps.Test/src/ProgramTest.cs
@@ -21,7 +21,7 @@ public sealed class ProgramTest : IDisposable
 		Assert.Equal(1, forceOps.Run());
 
 		Assert.IsType<AggregateException>(forceOps.caughtException);
-		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>?>()), Times.Once());
+		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>>()), Times.Once());
 	}
 
 	[Fact]
@@ -29,13 +29,13 @@ public sealed class ProgramTest : IDisposable
 	{
 		using var launchedProcess = LaunchProcessInDirectory(tempDirectoryPath);
 		var testContext = new TestContext();
-		testContext.relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated(It.IsAny<List<string>?>())).Returns(0);
+		testContext.relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated(It.IsAny<List<string>>())).Returns(0);
 		testContext.forceOpsContext.processKiller = new Mock<IProcessKiller>().Object;
 
 		var forceOps = new ForceOps(new[] { "delete", tempDirectoryPath }, testContext.forceOpsContext);
 		Assert.Equal(0, forceOps.Run());
 
-		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>?>()), Times.Once());
+		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>>()), Times.Once());
 	}
 
 	[Fact]
@@ -50,7 +50,7 @@ public sealed class ProgramTest : IDisposable
 		Assert.Equal(1, forceOps.Run());
 
 		Assert.IsType<IOException>(forceOps.caughtException);
-		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>?>()), Times.Never());
+		testContext.relaunchAsElevatedMock.Verify(t => t.RelaunchAsElevated(It.IsAny<List<string>>()), Times.Never());
 	}
 
 

--- a/ForceOps.Test/src/TestContext.cs
+++ b/ForceOps.Test/src/TestContext.cs
@@ -18,7 +18,7 @@ public class TestContext
 	public TestContext()
 	{
 		elevateUtilsMock.Setup(t => t.IsProcessElevated()).Returns(false);
-		relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated(It.IsAny<List<string>?>())).Returns(1);
+		relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated(It.IsAny<List<string>>())).Returns(1);
 		environmentExitMock
 			.Setup(t => t.Exit(It.IsAny<int>(), It.IsAny<string>()))
 			.Callback((int exitCode, string exitMessage) =>

--- a/ForceOps.Test/src/TestContext.cs
+++ b/ForceOps.Test/src/TestContext.cs
@@ -7,19 +7,32 @@ namespace ForceOps.Test;
 public class TestContext
 {
 	public ForceOpsContext forceOpsContext;
-	public Mock<IElevateUtils> elevateUtilsMock;
-	public Mock<IRelaunchAsElevated> relaunchAsElevatedMock;
-	public FakeLoggerFactory fakeLoggerFactory;
+	public Mock<IElevateUtils> elevateUtilsMock = new();
+	public Mock<IRelaunchAsElevated> relaunchAsElevatedMock = new();
+	public Mock<IEnvironmentExit> environmentExitMock = new();
+	public FakeLoggerFactory fakeLoggerFactory = new();
+
+	public ExitCode? friendlyExitCode;
+	public string? friendlyExitMessage;
 
 	public TestContext()
 	{
-		elevateUtilsMock = new Mock<IElevateUtils>();
 		elevateUtilsMock.Setup(t => t.IsProcessElevated()).Returns(false);
-		relaunchAsElevatedMock = new Mock<IRelaunchAsElevated>();
-		relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated()).Returns(1);
-		fakeLoggerFactory = new FakeLoggerFactory();
+		relaunchAsElevatedMock.Setup(t => t.RelaunchAsElevated(It.IsAny<List<string>?>())).Returns(1);
+		environmentExitMock
+			.Setup(t => t.Exit(It.IsAny<int>(), It.IsAny<string>()))
+			.Callback((int exitCode, string exitMessage) =>
+		{
+			friendlyExitCode = (ExitCode)exitCode;
+			friendlyExitMessage = exitMessage;
+		});
 
-		forceOpsContext = new ForceOpsContext(elevateUtils: elevateUtilsMock.Object, loggerFactory: fakeLoggerFactory, relaunchAsElevated: relaunchAsElevatedMock.Object);
+		forceOpsContext = new ForceOpsContext(
+			elevateUtils: elevateUtilsMock.Object,
+			loggerFactory: fakeLoggerFactory,
+			relaunchAsElevated: relaunchAsElevatedMock.Object,
+			environmentExit: environmentExitMock.Object
+		);
 	}
 }
 

--- a/ForceOps.Test/src/TestUtil.cs
+++ b/ForceOps.Test/src/TestUtil.cs
@@ -23,7 +23,7 @@ public static class TestUtil
 			{
 				FileName = "powershell",
 				WorkingDirectory = workingDirectory,
-				Arguments = $"-NoProfile -Command \"{command}; echo 'process has been loaded'; sleep 10\"",
+				Arguments = $"-NoProfile -Command \"{command}; echo 'process has been loaded'; sleep 10000\"",
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 				CreateNoWindow = true

--- a/ForceOps.Test/src/TestUtil.cs
+++ b/ForceOps.Test/src/TestUtil.cs
@@ -50,9 +50,9 @@ public static class TestUtil
 		while (!(output.LastOrDefault() ?? "").EndsWith("process has been loaded") && !process.HasExited)
 		{
 			Thread.Sleep(50);
-			if (DateTime.Now.Subtract(startTime).TotalSeconds > 2)
+			if (DateTime.Now.Subtract(startTime).TotalSeconds > 5)
 			{
-				throw new Exception("Gave up after waiting 2 seconds");
+				throw new Exception("Gave up after waiting 5 seconds");
 			}
 		}
 

--- a/ForceOps/ForceOps.csproj
+++ b/ForceOps/ForceOps.csproj
@@ -2,11 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <RollForward>LatestMajor</RollForward>
-        <LangVersion>latest</LangVersion>
         <IsPackable>true</IsPackable>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/ForceOps/Properties/launchSettings.json
+++ b/ForceOps/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ForceOps": {
       "commandName": "Project",
-      "commandLineArgs": "delete C:\\testfile"
+      "commandLineArgs": "delete -f C:\\testfile"
     }
   }
 }

--- a/ForceOps/src/ExitCode.cs
+++ b/ForceOps/src/ExitCode.cs
@@ -1,0 +1,7 @@
+﻿namespace ForceOps;
+
+public enum ExitCode
+{
+	Success = 0,
+	FileNotFound = 64
+}

--- a/ForceOps/src/ForceOps.cs
+++ b/ForceOps/src/ForceOps.cs
@@ -1,0 +1,134 @@
+﻿using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using ForceOps.Lib;
+using Serilog;
+
+namespace ForceOps;
+
+internal class ForceOps
+{
+	readonly internal ForceOpsContext forceOpsContext = new();
+	readonly ILogger logger;
+	readonly string[] args;
+	internal Exception? caughtException = null;
+	internal List<string>? extraRelaunchArgs = null;
+
+	public ForceOps(string[] args, ForceOpsContext? forceOpsContext = null, ILogger? logger = null)
+	{
+		this.forceOpsContext = forceOpsContext ?? new ForceOpsContext();
+		this.logger = logger ?? this.forceOpsContext.loggerFactory.CreateLogger<ForceOps>();
+		this.args = args;
+	}
+
+	public int Run()
+	{
+		var rootCommand = new RootCommand("By hook or by crook, perform operations on files and directories. If they are in use by a process, kill the process.")
+		{
+			Name = "forceops"
+		};
+		rootCommand.AddCommand(CreateDeleteCommand());
+
+		var parser = new CommandLineBuilder(rootCommand)
+			.UseDefaults()
+			.AddMiddleware(async (context, next) =>
+			{
+				try
+				{
+					await next(context);
+				}
+				catch (Exception ex)
+				{
+					caughtException = ex;
+					if (ex is FileNotFoundException fileNotFoundEx)
+					{
+						forceOpsContext.environmentExit.Exit((int)ExitCode.FileNotFound, $"Cannot remove '{fileNotFoundEx.Message}'. No such file or directory");
+					}
+					throw;
+				}
+			})
+			.Build();
+
+		return parser.Invoke(args);
+	}
+
+	public Command CreateDeleteCommand()
+	{
+		var filesToDeleteArgument = new Argument<string[]>("files", "Files or directories to delete.")
+		{
+			Arity = ArgumentArity.OneOrMore
+		};
+
+		var forceOption = new Option<bool>(new[] { "-f", "--force" }, "Ignore nonexistent files and arguments");
+		var disableElevate = new Option<bool>(new[] { "-e", "--disable-elevate" }, "Do not attempt to elevate if the file can't be deleted");
+
+		var deleteCommand = new Command("delete", "Delete files or a directories recursively.")
+		{
+			filesToDeleteArgument,
+			forceOption,
+			disableElevate
+		};
+
+		deleteCommand.AddAlias("rm");
+		deleteCommand.SetHandler(DeleteCommand, filesToDeleteArgument, forceOption, disableElevate);
+		return deleteCommand;
+	}
+
+	void DeleteCommand(string[] filesOrDirectoriesToDelete, bool force, bool disableElevate)
+	{
+		RunWithRelaunchAsElevated(() =>
+		{
+			var deleter = new FileAndDirectoryDeleter(forceOpsContext);
+			filesOrDirectoriesToDelete = filesOrDirectoriesToDelete.Select(file => DirectoryUtils.CombineWithCWDAndGetAbsolutePath(file)).ToArray();
+			foreach (var file in filesOrDirectoriesToDelete)
+			{
+				deleter.DeleteFileOrDirectory(file, force);
+			}
+		}, BuildArgsForRelaunch, disableElevate);
+	}
+
+	List<string> BuildArgsForRelaunch()
+	{
+		var newArgs = args.ToList();
+		if (!newArgs.Any(arg => arg == "-f" || arg == "--force"))
+		{
+			newArgs.Add("-f");
+		}
+		if (extraRelaunchArgs != null)
+		{
+			newArgs.AddRange(extraRelaunchArgs);
+		}
+		return newArgs;
+	}
+
+	void RunWithRelaunchAsElevated(Action action, Func<List<string>> buildArgsForRelaunch, bool disableElevate)
+	{
+		try
+		{
+			action();
+		}
+		catch (Exception ex) when (ExceptionCausedByPermissions(ex) && !forceOpsContext.elevateUtils.IsProcessElevated() && !disableElevate)
+		{
+			logger.Information("Unable to perform operation as an unelevated process. Retrying as elevated.");
+			var args = buildArgsForRelaunch();
+			var childProcessExitCode = forceOpsContext.relaunchAsElevated.RelaunchAsElevated(args);
+			if (childProcessExitCode != 0)
+			{
+				throw new AggregateException($"Child process failed with {childProcessExitCode}. See inner exception for the previous exception.", ex);
+			}
+			else
+			{
+				logger.Information("Successfully deleted as admin");
+			}
+		}
+	}
+
+	static bool ExceptionCausedByPermissions(Exception ex)
+	{
+		if (ex is FileNotFoundException)
+		{
+			return false;
+		}
+		return ex is IOException || ex is UnauthorizedAccessException;
+	}
+}

--- a/ForceOps/src/Program.cs
+++ b/ForceOps/src/Program.cs
@@ -1,66 +1,12 @@
-﻿using System.CommandLine;
-using System.Runtime.Versioning;
-using ForceOps.Lib;
-using Serilog;
+﻿using System.Runtime.Versioning;
 
 namespace ForceOps;
 
 [SupportedOSPlatform("windows")]
 public class Program
 {
-	internal static ForceOpsContext forceOpsContext = new();
-	static readonly ILogger logger = forceOpsContext.loggerFactory.CreateLogger<Program>();
-	internal static bool CanRelaunchAsElevated = true;
-
-	static int Main(string[] args)
+	public static int Main(string[] args)
 	{
-		var rootCommand = new RootCommand("By hook or by crook, perform operations on files and directories. If they are in use by a process, kill the process.") { Name = "forceops" };
-
-		var filesToDeleteArgument = new Argument<string[]>(
-			name: "files",
-			description: "Files or directories to delete.")
-		{
-			Arity = ArgumentArity.OneOrMore
-		};
-		var deleteCommand = new Command("delete", "Delete files or a directories recursively.") { filesToDeleteArgument };
-		deleteCommand.AddAlias("rm");
-		deleteCommand.SetHandler(DeleteCommand, filesToDeleteArgument);
-		rootCommand.AddCommand(deleteCommand);
-
-		return rootCommand.Invoke(args);
-	}
-
-	internal static void DeleteCommand(string[] filesOrDirectoriesToDelete)
-	{
-		RunWithRelaunchAsElevated(() =>
-		{
-			var deleter = new FileAndDirectoryDeleter(forceOpsContext);
-			filesOrDirectoriesToDelete = filesOrDirectoriesToDelete.Select(file => DirectoryUtils.CombineWithCWDAndGetAbsolutePath(file)).ToArray();
-			foreach (var file in filesOrDirectoriesToDelete)
-			{
-				deleter.DeleteFileOrDirectory(file);
-			}
-		});
-	}
-
-	static void RunWithRelaunchAsElevated(Action action)
-	{
-		try
-		{
-			action();
-		}
-		catch (Exception ex) when ((ex is IOException || ex is UnauthorizedAccessException) && !forceOpsContext.elevateUtils.IsProcessElevated())
-		{
-			logger.Information("Unable to perform operation as an unelevated process. Retrying as elevated.");
-			var childProcessExitCode = forceOpsContext.relaunchAsElevated.RelaunchAsElevated();
-			if (childProcessExitCode != 0)
-			{
-				throw new AggregateException($"Child process failed with {childProcessExitCode}. See inner exception for the previous exception.", ex);
-			}
-			else
-			{
-				logger.Information("Successfully deleted as admin");
-			}
-		}
+		return new ForceOps(args).Run();
 	}
 }


### PR DESCRIPTION
* Deleting non-existing file now throws an error
* Add `--force` and `--disable-elevate` flags
* When re-launching as admin, `--force` is implied to avoid edge cases with partial deletions