### PR TITLE
Prevent hanging on process kill

### DIFF
--- a/ForceOps.Lib/src/ForceOpsContext/ProcessKiller.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/ProcessKiller.cs
@@ -22,23 +22,16 @@ internal class ProcessKiller : IProcessKiller
 			catch (ArgumentException) { } // If the process is no longer running
 		}
 
-		var killedProcesses = new List<Process>();
 		foreach (var process in runningProcesses)
 		{
 			try
 			{
 				process.Kill();
-				killedProcesses.Add(process);
 			}
 			catch (Win32Exception ex) // e.g. if the process is owned by another user
 			{
 				logger.Warning($"Failed to kill process {process.Id}: {ex.Message}");
 			}
-		}
-
-		foreach (var process in killedProcesses)
-		{
-			process.WaitForExit();
 		}
 	}
 }


### PR DESCRIPTION
There are some cases where a process ignores `SIGKILL`, so we should not wait for the process to exit when we call `process.Kill()`