### PR TITLE
Use LockChecker instead of submodule

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,16 +14,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-      - name: Build Deps
-        run: |
-          cd subrepos/LockCheck;
-          dotnet build -c release
       - name: Run benchmark
         run: cd ForceOps.Benchmarks && dotnet run -c release --exporters json --filter '*'
       - name: Store benchmark result

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0 # Required by LockCheck CI
 
       - name: Install Dotnet
         uses: actions/setup-dotnet@v4
@@ -27,11 +24,6 @@ jobs:
 
       - name: Dotnet Installation Info
         run: dotnet --info
-
-      - name: Build Deps
-        run: |
-          cd subrepos/LockCheck;
-          dotnet build -c release
 
       - name: Build
         run: dotnet build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
 
       - name: Get version
         id: get_version
@@ -44,11 +41,6 @@ jobs:
 
       - name: Dotnet Installation Info
         run: dotnet --info
-
-      - name: Build Deps
-        run: |
-          cd subrepos/LockCheck;
-          dotnet build -c release
 
       - name: Pack
         run: dotnet pack -c release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subrepos/LockCheck"]
-	path = subrepos/LockCheck
-	url = https://github.com/domsleee/LockCheck.git

--- a/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
+++ b/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
@@ -4,8 +4,8 @@ using ForceOps.Lib;
 
 namespace ForceOps.Benchmarks;
 
-// [SimpleJob(RuntimeMoniker.NativeAot70)]
-[SimpleJob(RuntimeMoniker.Net70)]
+// [SimpleJob(RuntimeMoniker.NativeAot80)]
+[SimpleJob(RuntimeMoniker.Net80)]
 public class FileAndDirectoryDeleterBenchmark
 {
 	readonly List<byte[]> fileDatas = new();

--- a/ForceOps.Lib/ForceOps.Lib.csproj
+++ b/ForceOps.Lib/ForceOps.Lib.csproj
@@ -11,7 +11,7 @@
 		<None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="LockCheck" Version="0.9.29-g6b3e993968" />
+		<PackageReference Include="LockChecker" Version="0.9.30-g4f01a64a51" />
 		<PackageReference Include="Serilog" Version="3.0.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
 	</ItemGroup>

--- a/ForceOps.Test/ForceOps.Test.csproj
+++ b/ForceOps.Test/ForceOps.Test.csproj
@@ -7,15 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local-packages" value="./subrepos/LockCheck/LockCheck/bin/Release" />
-  </packageSources>
-</configuration>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Forcefully perform file operations by terminating processes that are using the f
 
 Only supports windows, and not planned to support linux.
 
-Uses [LockCheck](https://github.com/cklutz/LockCheck) to find processes locking files, and will elevate itself if it the process is owned by another user.
+Uses [LockChecker](https://github.com/domsleee/LockCheck) to find processes locking files, and will elevate itself if it the process is owned by another user.
 
 See [Benchmarks](https://domsleee.github.io/ForceOps/) on github pages.
 

--- a/subrepos/Directory.Build.props
+++ b/subrepos/Directory.Build.props
@@ -1,3 +1,0 @@
-<!-- Dummy Directory.Build.props is required to skip the root Directory.Build.props -->
-<Project>
-</Project>

--- a/subrepos/NuGet.config
+++ b/subrepos/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <disabledPackageSources>
-    <add key="local-packages" value="true" />
-  </disabledPackageSources>
-</configuration>


### PR DESCRIPTION
* Use [LockChecker](https://www.nuget.org/packages/lockchecker), a fork of [LockCheck](https://github.com/cklutz/LockCheck), instead of git submodules

It makes the build faster and it makes it easier to use [ForceOps.Lib](https://www.nuget.org/packages/ForceOps.Lib)