### PR TITLE
chore(release): 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Release 1.4.1
+* Use `ContinuousIntegrationBuild` flag for deterministic builds by @domsleee in https://github.com/domsleee/ForceOps/pull/34
+
 ## Release 1.4.0
 * Update to use .NET8 ([.NET7 end of life was 14th May 2024](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core))
 * Change defaults:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.4.0</Version>
+        <Version>1.4.1</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
* Use `ContinuousIntegrationBuild` flag for deterministic builds