### PR TITLE
chore(release): 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 1.4.2
+* Improve test reliability and fix workstation domain trust issue by @domsleee in https://github.com/domsleee/ForceOps/pull/37
+* Remove ForceOps.Test from release build by @domsleee in https://github.com/domsleee/ForceOps/pull/36
+
 ## Release 1.4.1
 * Use `ContinuousIntegrationBuild` flag for deterministic builds by @domsleee in https://github.com/domsleee/ForceOps/pull/34
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.4.1</Version>
+        <Version>1.4.2</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
* Improve test reliability and fix workstation domain trust issue
* Remove ForceOps.Test from release build
