### PR TITLE
Ignore RmGetList() error 5: Access is denied.

### DIFF
--- a/ForceOps.Test/ForceOps.Test.csproj
+++ b/ForceOps.Test/ForceOps.Test.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">

--- a/ForceOps.Test/src/TestContext.cs
+++ b/ForceOps.Test/src/TestContext.cs
@@ -44,6 +44,8 @@ public class FakeLoggerFactory : ILoggerFactory
 	{
 		var logger = new Mock<ILogger>();
 		logger.Setup(t => t.Information(It.IsAny<string>())).Callback<string>(line => { Logs.Add(line); });
+		logger.Setup(t => t.Warning(It.IsAny<string>())).Callback<string>(line => { Logs.Add(line); });
+		logger.Setup(t => t.Error(It.IsAny<string>())).Callback<string>(line => { Logs.Add(line); });
 		return logger.Object;
 	}
 


### PR DESCRIPTION
The RestartManager API can throw `error 5: Access is denied.`. It should be ignored, sometimes the user wants to ignore files owned by the administrator, for example.

Previous behaviour

```shell
❯ forceops rm .\aaa.txt
Unhandled exception: System.ComponentModel.Win32Exception (5): Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
   at LockCheck.Windows.RestartManager.GetLockingProcessInfos(String[] paths) in /_/LockCheck/Windows/RestartManager.cs:line 72
   at LockCheck.LockManager.GetLockingProcessInfos(String[] paths, LockManagerFeatures features) in /_/LockCheck/LockManager.cs:line 21
   at ForceOps.Lib.FileAndDirectoryDeleter.<>c__DisplayClass4_0.<DeleteFile>b__0() in /_/ForceOps.Lib/src/FileAndDirectoryDeleter.cs:line 58
   at ForceOps.Lib.FileAndDirectoryDeleter.KillProcessesAndLogInfo(Boolean isDirectory, Int32 attemptNumber, String fileOrDirectoryPath, Func`1 getProcessesLockingFileFunc) in /_/ForceOps.Lib/src/FileAndDirectoryDeleter.cs:line 78
   at ForceOps.Lib.FileAndDirectoryDeleter.DeleteFile(FileInfo file) in /_/ForceOps.Lib/src/FileAndDirectoryDeleter.cs:line 59
   at ForceOps.Lib.FileAndDirectoryDeleter.DeleteFileOrDirectory(String fileOrDirectory, Boolean force) in /_/ForceOps.Lib/src/FileAndDirectoryDeleter.cs:line 30
   at ForceOps.ForceOps.<>c__DisplayClass8_0.<DeleteCommand>b__0() in /_/ForceOps/src/ForceOps.cs:line 94
   at ForceOps.ForceOps.RunWithRelaunchAsElevated(Action action, Func`1 buildArgsForRelaunch, Boolean disableElevate) in /_/ForceOps/src/ForceOps.cs:line 133
   at ForceOps.ForceOps.DeleteCommand(String[] filesOrDirectoriesToDelete, Boolean force, Boolean disableElevate, Int32 retryDelay, Int32 maxRetries) in /_/ForceOps/src/ForceOps.cs:line 86
```

New behaviour

```shell
❯ forceops rm .\aaa.txt
[22:48:45 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:45 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 1/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:45 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:45 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 2/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:45 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:45 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 3/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 4/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 5/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 6/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 7/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 8/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 9/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 WRN] Ignored exception: Failed to get entries (retry 0). (RmGetList() error 5: Access is denied.)
[22:48:46 INF] Could not delete file "C:\Users\user\aaa.txt". Beginning retry 10/10 in 50ms. ForceOps process is not elevated. Found 0 processes to try to kill: [].
[22:48:46 INF] Exceeded retry count of 10. Failed. ForceOps process is not elevated.
[22:48:46 INF] Unable to perform operation as an unelevated process. Retrying as elevated and logging to "C:\Users\user\AppData\Local\Temp\tmpgkkdu1.tmp".
[22:48:47 INF] Successfully deleted as admin
```