### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 1.5.0
+* Add ForceOps.Lib example (ForceOps.DeleteExample) and docs to README.md by @domsleee in https://github.com/domsleee/ForceOps/pull/41
+* Ignore RmGetList() error 5: Access is denied. by @domsleee in https://github.com/domsleee/ForceOps/pull/42
+
 ## Release 1.4.3
 * Include symbols with ForceOps.Lib by @domsleee in https://github.com/domsleee/ForceOps/pull/39
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.4.3</Version>
+        <Version>1.5.0</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
* Add ForceOps.Lib example (ForceOps.DeleteExample) and docs to README.md
* Ignore RmGetList() error 5: Access is denied.