### PR TITLE
Refactor CLI

### DIFF
--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -61,7 +61,7 @@ public class FileAndDirectoryDeleter
 				{
 					try
 					{
-						return GetLockingProcessInfos(new[] { file.FullName });
+						return GetLockingProcessInfos([file.FullName]);
 					}
 					catch (Win32Exception e)
 					{

--- a/ForceOps.Lib/src/ForceOpsContext/RelaunchHelpers.cs
+++ b/ForceOps.Lib/src/ForceOpsContext/RelaunchHelpers.cs
@@ -15,7 +15,7 @@ public static class RelaunchHelpers
 		{
 			var args = buildArgsForRelaunch();
 			var childOutputFile = GetChildOutputFile();
-			args.AddRange(new[] { "2>&1", ">", childOutputFile });
+			args.AddRange(["2>&1", ">", childOutputFile]);
 			logger.Information($"Unable to perform operation as an unelevated process. Retrying as elevated and logging to \"{childOutputFile}\".");
 			var childProcessExitCode = forceOpsContext.relaunchAsElevated.RelaunchAsElevated(args, childOutputFile);
 			if (childProcessExitCode != 0)

--- a/ForceOps/src/Program.cs
+++ b/ForceOps/src/Program.cs
@@ -1,12 +1,92 @@
-﻿using System.Runtime.Versioning;
+﻿using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using System.Runtime.Versioning;
 
 namespace ForceOps;
 
 [SupportedOSPlatform("windows")]
 public class Program
 {
-	public static int Main(string[] args)
+	public static int Main(string[] args) => new ForceOpsRunner(new ForceOps(args)).Run();
+}
+
+internal class ForceOpsRunner
+{
+	readonly ForceOps _forceOps;
+	public ForceOpsRunner(ForceOps forceOps)
 	{
-		return new ForceOps(args).Run();
+		_forceOps = forceOps;
+	}
+
+	internal int Run()
+	{
+		var rootCommand = new RootCommand("By hook or by crook, perform operations on files and directories. If they are in use by a process, kill the process.")
+		{
+			Name = "forceops"
+		};
+		rootCommand.AddCommand(CreateDeleteCommand());
+		rootCommand.AddCommand(CreateListCommand());
+
+		var parser = new CommandLineBuilder(rootCommand)
+			.UseDefaults()
+			.AddMiddleware(async (context, next) =>
+			{
+				try
+				{
+					await next(context);
+				}
+				catch (Exception ex)
+				{
+					_forceOps.caughtException = ex;
+
+					if (ex is FileNotFoundException fileNotFoundEx)
+					{
+						_forceOps.forceOpsContext.environmentExit.Exit((int)ExitCode.FileNotFound, ex.Message);
+					}
+					throw;
+				}
+			})
+			.Build();
+
+		return parser.Invoke(_forceOps.args);
+	}
+
+	Command CreateDeleteCommand()
+	{
+		var filesToDeleteArgument = new Argument<string[]>("files", "Files or directories to delete.")
+		{
+			Arity = ArgumentArity.OneOrMore
+		};
+
+		var forceOption = new Option<bool>(["-f", "--force"], "Ignore nonexistent files and arguments.");
+		var disableElevate = new Option<bool>(["-e", "--disable-elevate"], "Do not attempt to elevate if the file can't be deleted.");
+		var retryDelay = new Option<int>(["-d", "--retry-delay"], () => 50, "Delay when retrying to delete a file, after deleting processes holding a lock.");
+		var maxRetries = new Option<int>(["-n", "--max-retries"], () => 10, "Number of retries when deleting a locked file.");
+
+		var deleteCommand = new Command("delete", "Delete files or a directories recursively.")
+		{
+			filesToDeleteArgument,
+			forceOption,
+			disableElevate,
+			retryDelay,
+			maxRetries
+		};
+
+		deleteCommand.AddAlias("rm");
+		deleteCommand.AddAlias("remove");
+		deleteCommand.SetHandler(_forceOps.DeleteCommand, filesToDeleteArgument, forceOption, disableElevate, retryDelay, maxRetries);
+		return deleteCommand;
+	}
+
+	Command CreateListCommand()
+	{
+		var fileOrDirectoryArgument = new Argument<string>("fileOrDirectory", "File or directory to get the locks of.");
+		var listCommand = new Command("list", "Uses LockCheck to output processes using a file or directory.")
+		{
+			fileOrDirectoryArgument
+		};
+		listCommand.SetHandler(_forceOps.ListCommand, fileOrDirectoryArgument);
+		return listCommand;
 	}
 }

--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ Uses [LockChecker](https://github.com/domsleee/LockCheck) to find processes lock
 
 ## Installation
 
-```shell
-dotnet tool install -g forceops
-```
+| Method   | Install                                                                                             | Update                           |
+| -------- | --------------------------------------------------------------------------------------------------- | -------------------------------- |
+| scoop    | `scoop install https://gist.github.com/domsleee/f765105f512ec607ee0a6e3ee5debd6d/raw/forceops.json` | `scoop update forceops --force`  |
+| dotnet   | `dotnet tool install -g forceops`                                                                   | `dotnet tool update -g forceops` |
+| releases | Download from [latest release](https://github.com/domsleee/ForceOps/releases)                       |                                  |
 
-To update:
-```
-dotnet tool update -g forceops
-```
-
-Alternatively, the executable is available for download in [the latest release]([releases](https://github.com/domsleee/ForceOps/releases/atest)).
 
 
 ## Usage: As a CLI

--- a/README.md
+++ b/README.md
@@ -11,13 +11,31 @@ Uses [LockChecker](https://github.com/domsleee/LockCheck) to find processes lock
 
 ## Installation
 
-| Method   | Install                                                                                             | Update                           |
-| -------- | --------------------------------------------------------------------------------------------------- | -------------------------------- |
-| scoop    | `scoop install https://gist.github.com/domsleee/f765105f512ec607ee0a6e3ee5debd6d/raw/forceops.json` | `scoop update forceops --force`  |
-| dotnet   | `dotnet tool install -g forceops`                                                                   | `dotnet tool update -g forceops` |
-| releases | Download from [latest release](https://github.com/domsleee/ForceOps/releases)                       |                                  |
+### Install with [`scoop`](http://scoop.sh/) (recommended)
+It has a faster startup because it uses [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/):
 
+```shell
+scoop install https://gist.github.com/domsleee/f765105f512ec607ee0a6e3ee5debd6d/raw/forceops.json
+```
 
+To update:
+```shell
+scoop update forceops --force
+```
+
+### Alternative - install with [`dotnet`](https://dotnet.microsoft.com/en-us/download)
+
+```shell
+dotnet tool install -g forceops
+```
+
+To update:
+```shell
+dotnet tool update -g forceops
+```
+
+### Alternative - install from releases
+Download the latest exe from [releases](https://github.com/domsleee/ForceOps/releases).
 
 ## Usage: As a CLI
 ### Deleting when a process owned by the current user is using it

--- a/installLocal.ps1
+++ b/installLocal.ps1
@@ -5,5 +5,5 @@ pwsh -NoProfile -Command {
     {
         dotnet tool uninstall -g ForceOps
     }
-    dotnet tool install -g ForceOps --prerelease --configfile "../scripts/LocalNuGet.config" --no-cache
+    dotnet tool install -g ForceOps --configfile "../scripts/LocalNuGet.config" --no-cache
 }


### PR DESCRIPTION
* Move CLI logic into one file
* Update README for scoop install

I also checked out alternatives to [System.CommandLine](https://github.com/dotnet/command-line-api):

| CLI library           | Notes                                                                                                                                                 |
| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| [Spectre.Console.Cli] | Does not support NativeAOT because it uses reflection, see https://github.com/spectreconsole/spectre.console/issues/1332#issuecomment-2439569808      |
| [ConsoleAppFramework] | Does not support variadic args, which is needed for `forceops delete file1 file2 .. filen`, https://github.com/Cysharp/ConsoleAppFramework/issues/179 |
| [Cocona.Lite]         | It works but it was a bit slower and didn't have any benefits over System.CommandLine                                                                |

[Spectre.Console.Cli]: https://spectreconsole.net/cli/
[ConsoleAppFramework]: https://github.com/Cysharp/ConsoleAppFramework
[Cocona.Lite]: https://github.com/mayuki/Cocona