### PR TITLE
feat: update to .NET 10

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
       - name: Run benchmark
         run: cd ForceOps.Benchmarks && dotnet run -c release --exporters json --filter '*'
       - name: Store benchmark result

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Dotnet Installation Info
         run: dotnet --info

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Directory structure
         run: |
@@ -61,7 +61,7 @@ jobs:
         with:
           draft: true
           name: "${{ steps.get_version.outputs.version }}"
-          files: ForceOps/bin_aot/Release/net9.0/win-x64/publish/ForceOps.exe
+          files: ForceOps/bin_aot/Release/net10.0/win-x64/publish/ForceOps.exe
           tag_name: "${{ steps.get_version.outputs.version }}"
 
       - name: Publish NuGet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
         <PackageReleaseNotes>https://github.com/domsleee/forceops/blob/main/CHANGELOG.md</PackageReleaseNotes>
         <IsPackable>false</IsPackable>
 
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
NUL / reserved device name deletion has been split off to #48.

## Changes

### .NET 10 upgrade
- Update `TargetFramework` from `net9.0` to `net10.0`
- Update `global.json` SDK from `9.0.200` to `10.0.100`
- Update all CI workflows (`ci.yaml`, `release.yaml`, `benchmark.yaml`) to `dotnet 10.0.x`
- Update AOT publish path in release workflow (`net9.0` → `net10.0`)

No version bump here - `1.5.1` -> `1.6.0` moved to #48.
