### PR TITLE
feat: support deleting reserved device name files (NUL, CON, PRN, etc.)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.5.1</Version>
+        <Version>1.6.0</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/ForceOps.Lib/src/DirectoryUtils.cs
+++ b/ForceOps.Lib/src/DirectoryUtils.cs
@@ -1,11 +1,28 @@
-﻿namespace ForceOps.Lib;
+﻿using System.Text.RegularExpressions;
+
+namespace ForceOps.Lib;
 
 public static class DirectoryUtils
 {
+	static readonly Regex ReservedDeviceNamePattern = new(
+		@"^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\..+)?$",
+		RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
 	public static string CombineWithCWDAndGetAbsolutePath(string path)
 	{
 		string currentDirectory = Directory.GetCurrentDirectory();
-		return Path.GetFullPath(Path.Combine(currentDirectory, path));
+		string combined = Path.Combine(currentDirectory, path);
+
+		// Path.GetFullPath resolves reserved device names (NUL, CON, etc.) to \\.\NUL.
+		// Resolve the parent directory instead and re-append the filename.
+		string fileName = Path.GetFileName(combined);
+		if (IsReservedDeviceName(fileName))
+		{
+			string parentDir = Path.GetFullPath(Path.GetDirectoryName(combined)!);
+			return Path.Combine(parentDir, fileName);
+		}
+
+		return Path.GetFullPath(combined);
 	}
 
 	public static bool IsSymLink(string folder) => IsSymLink(new DirectoryInfo(folder));
@@ -21,5 +38,25 @@ public static class DirectoryUtils
 		{
 			fileSystemInfo.Attributes &= ~FileAttributes.ReadOnly;
 		}
+	}
+
+	public static bool IsReservedDeviceName(string path)
+	{
+		var fileName = Path.GetFileName(path);
+		return ReservedDeviceNamePattern.IsMatch(fileName);
+	}
+
+	public static bool TryDeleteReservedDeviceNameFile(string absolutePath)
+	{
+		if (!IsReservedDeviceName(absolutePath))
+			return false;
+
+		var extendedPath = @"\\?\" + absolutePath;
+		if (File.Exists(extendedPath))
+		{
+			File.Delete(extendedPath);
+		}
+
+		return true;
 	}
 }

--- a/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
+++ b/ForceOps.Lib/src/FileAndDirectoryDeleter.cs
@@ -36,6 +36,10 @@ public class FileAndDirectoryDeleter
 			DeleteDirectory(new DirectoryInfo(fileOrDirectory));
 			return;
 		}
+		if (TryDeleteReservedDeviceNameFile(fileOrDirectory))
+		{
+			return;
+		}
 
 		if (!force)
 		{
@@ -54,9 +58,12 @@ public class FileAndDirectoryDeleter
 				file.Delete();
 				break;
 			}
-			catch when (!file.Exists) { }
+			catch when (!file.Exists && !IsReservedDeviceName(file.FullName)) { }
 			catch (Exception ex) when (ex is IOException || ex is System.UnauthorizedAccessException)
 			{
+				if (TryDeleteReservedDeviceNameFile(file.FullName))
+					return;
+
 				var getProcessesLockingFileFunc = () =>
 				{
 					try

--- a/ForceOps.Test/src/FileAndDirectoryDeleterTest.cs
+++ b/ForceOps.Test/src/FileAndDirectoryDeleterTest.cs
@@ -87,6 +87,34 @@ Could not delete file .*. Beginning retry 1/10 in 50ms. ForceOps process is not 
 Could not delete file .*. Beginning retry 1/10 in 50ms. ForceOps process is not elevated. Found 1 process to try to kill: \[\d+ \- powershell.exe\]", testContext.fakeLoggerFactory.GetAllLogsString());
 	}
 
+	[Fact]
+	public void DeletingFileWithReservedDeviceName()
+	{
+		var nulFilePath = Path.Combine(tempFolderPath, "nul");
+		var extendedPath = @"\\?\" + nulFilePath;
+
+		File.Create(extendedPath).Dispose();
+		Assert.True(File.Exists(extendedPath));
+
+		fileAndDirectoryDeleter.DeleteFileOrDirectory(nulFilePath, false);
+
+		Assert.False(File.Exists(extendedPath));
+	}
+
+	[Fact]
+	public void DeletingDirectoryContainingFileWithReservedDeviceName()
+	{
+		var nulFilePath = Path.Combine(tempFolderPath, "nul");
+		var extendedPath = @"\\?\" + nulFilePath;
+
+		File.Create(extendedPath).Dispose();
+		Assert.True(File.Exists(extendedPath));
+
+		fileAndDirectoryDeleter.DeleteDirectory(new DirectoryInfo(tempFolderPath));
+
+		Assert.False(Directory.Exists(tempFolderPath));
+	}
+
 	public ForceOpsMethodsTest()
 	{
 		tempFolderPath = GetTemporaryFileName();


### PR DESCRIPTION
@
Split off from #47 (which now contains only the .NET 10 upgrade).

## Changes

### Reserved device name file deletion (NUL, CON, PRN, etc.)
On Windows, files named `nul`, `con`, `prn`, etc. are reserved device names that cannot be deleted with standard APIs. These files can be created by cross-platform tools (e.g. git cloning a repo from Linux).

This PR adds support for deleting them using the `\?\` extended-length path prefix:
- Detect reserved device names via regex in `DirectoryUtils.IsReservedDeviceName`
- Use `\?\` prefix for `File.Exists` and `File.Delete` on reserved names
- Handle `Path.GetFullPath` resolving reserved names to `\.\` by resolving the parent directory separately
- Works for both direct deletion (`DeleteFileOrDirectory`) and recursive directory deletion (`DeleteFilesInFolder`)

Reference: https://gist.github.com/domsleee/c0e01497faa89667dc989630cab21945

### Version bump
- `1.5.1` -> `1.6.0`

### Tests
- `DeletingFileWithReservedDeviceName` - creates a `nul` file and deletes it directly
- `DeletingDirectoryContainingFileWithReservedDeviceName` - deletes a directory containing a `nul` file
- Full suite passes locally on net9.0 (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@