### PR TITLE
feat: RID-specific Native AOT dotnet tool packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,13 +47,22 @@ jobs:
           dotnet pack ForceOps -c release -r win-x64 /p:ContinuousIntegrationBuild=true
           dotnet pack ForceOps -c release -r any -p:PublishAot=false /p:ContinuousIntegrationBuild=true
 
+      # The .sha256 sidecar is used by the scoop bucket's autoupdate
+      # (https://github.com/domsleee/scoop-bucket).
+      - name: Create sha256 for release exe
+        run: |
+          $exe = "ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe"
+          (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower() | Set-Content -NoNewline "$exe.sha256"
+
       - name: Create release
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           name: "${{ steps.get_version.outputs.version }}"
-          files: ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe
+          files: |
+            ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe
+            ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe.sha256
           tag_name: "${{ steps.get_version.outputs.version }}"
 
       # RID-specific packages must be on the feed before the top-level pointer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,15 +44,8 @@ jobs:
       - name: Pack
         run: |
           dotnet pack -c release /p:ContinuousIntegrationBuild=true
-          cp -r ForceOps/nupkg ForceOps/nupkg_pack
-          cp -r ForceOps.Lib/nupkg ForceOps.Lib/nupkg_pack
-          dotnet clean
-
-      - name: Build (AOT)
-        run: |
-          dotnet publish -c release /p:UseAot=1 /p:ContinuousIntegrationBuild=true
-          cp -r ForceOps/bin ForceOps/bin_aot
-          dotnet clean
+          dotnet pack ForceOps -c release -r win-x64 /p:ContinuousIntegrationBuild=true
+          dotnet pack ForceOps -c release -r any -p:PublishAot=false /p:ContinuousIntegrationBuild=true
 
       - name: Create release
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
@@ -60,10 +53,13 @@ jobs:
         with:
           draft: true
           name: "${{ steps.get_version.outputs.version }}"
-          files: ForceOps/bin_aot/Release/net10.0/win-x64/publish/ForceOps.exe
+          files: ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe
           tag_name: "${{ steps.get_version.outputs.version }}"
 
+      # RID-specific packages must be on the feed before the top-level pointer
+      # package, so the pointer package is pushed in a second step.
       - name: Publish NuGet
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
         run: |
-          dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg_pack/ForceOps.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg_pack/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg_pack/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate
+          dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.win-x64.${{ steps.get_version.outputs.version }}.nupkg ForceOps/nupkg/ForceOps.any.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate
+          dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.${{ steps.get_version.outputs.version }}.nupkg --skip-duplicate

--- a/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
+++ b/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
@@ -3,7 +3,7 @@ using ForceOps.Lib;
 
 namespace ForceOps.Benchmarks;
 
-// [SimpleJob(RuntimeMoniker.NativeAot80)]
+// [SimpleJob(RuntimeMoniker.NativeAot10_0)]
 [SimpleJob]
 public class FileAndDirectoryDeleterBenchmark
 {

--- a/ForceOps/ForceOps.csproj
+++ b/ForceOps/ForceOps.csproj
@@ -9,14 +9,19 @@
         <PackageOutputPath>./nupkg</PackageOutputPath>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$(UseAot) != '1'">
+    <PropertyGroup>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>forceops</ToolCommandName>
-    </PropertyGroup>
 
-    <PropertyGroup Condition="'$(UseAot)' == '1'">
+        <!--
+            RID-specific tool packaging (requires .NET SDK 10+):
+            - `dotnet pack` produces the top-level pointer package.
+            - `dotnet pack -r win-x64` produces the self-contained Native AOT package.
+            - `dotnet pack -r any -p:PublishAot=false` produces the framework-dependent fallback.
+            RID packages must be pushed to NuGet before the pointer package.
+        -->
         <PublishAot>true</PublishAot>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <ToolPackageRuntimeIdentifiers>win-x64;any</ToolPackageRuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ForceOps/ForceOps.csproj
+++ b/ForceOps/ForceOps.csproj
@@ -13,13 +13,7 @@
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>forceops</ToolCommandName>
 
-        <!--
-            RID-specific tool packaging (requires .NET SDK 10+):
-            - `dotnet pack` produces the top-level pointer package.
-            - `dotnet pack -r win-x64` produces the self-contained Native AOT package.
-            - `dotnet pack -r any -p:PublishAot=false` produces the framework-dependent fallback.
-            RID packages must be pushed to NuGet before the pointer package.
-        -->
+        <!-- RID-specific tool packaging, see https://learn.microsoft.com/en-us/dotnet/core/tools/rid-specific-tools -->
         <PublishAot>true</PublishAot>
         <ToolPackageRuntimeIdentifiers>win-x64;any</ToolPackageRuntimeIdentifiers>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ scoop update forceops --force
 dotnet tool install -g forceops
 ```
 
+On x64 Windows this installs the [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) build (same fast startup as the scoop install). Other architectures get a framework-dependent build. Requires the .NET 10 SDK or later to install.
+
 To update:
 ```shell
 dotnet tool update -g forceops

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Uses [LockChecker](https://github.com/domsleee/LockCheck) to find processes lock
 ## Installation
 
 ### Install with [`scoop`](http://scoop.sh/) (recommended)
-It has a faster startup because it uses [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/):
+Installs the [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) build and doesn't require the .NET SDK:
 
 ```shell
 scoop bucket add domsleee https://github.com/domsleee/scoop-bucket
@@ -30,7 +30,7 @@ scoop update forceops
 dotnet tool install -g forceops
 ```
 
-On x64 Windows this installs the [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) build (same fast startup as the scoop install). Other architectures get a framework-dependent build. Requires the .NET 10 SDK or later to install.
+On x64 Windows this installs the same Native AOT build as the scoop install. Other architectures get a framework-dependent build. Requires the .NET 10 SDK or later to install.
 
 To update:
 ```shell

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ Uses [LockChecker](https://github.com/domsleee/LockCheck) to find processes lock
 It has a faster startup because it uses [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/):
 
 ```shell
-scoop install https://gist.github.com/domsleee/f765105f512ec607ee0a6e3ee5debd6d/raw/forceops.json
+scoop bucket add domsleee https://github.com/domsleee/scoop-bucket
+scoop install forceops
 ```
 
 To update:
 ```shell
-scoop update forceops --force
+scoop update forceops
 ```
 
 ### Alternative - install with [`dotnet`](https://dotnet.microsoft.com/en-us/download)


### PR DESCRIPTION
Uses [RID-specific tool packaging](https://learn.microsoft.com/en-us/dotnet/core/tools/rid-specific-tools) (.NET SDK 10) so `dotnet tool install -g forceops` installs the Native AOT binary on x64 Windows, with a framework-dependent `any` fallback for other architectures.

* Removes the `UseAot=1` conditional build; the GitHub release exe now comes from the `win-x64` pack output
* `dotnet pack` produces three tool packages: pointer (10 KB), `ForceOps.win-x64` Native AOT (6.2 MB), `ForceOps.any` framework-dependent (385 KB). RID packages are pushed to NuGet before the pointer package, as required

Verified locally that installing through the pointer package selects the win-x64 AOT exe automatically.

## Performance

Native AOT vs framework-dependent ([hyperfine](https://github.com/sharkdp/hyperfine)):

| Scenario | Native AOT | Framework-dependent | Speedup |
| --- | --- | --- | --- |
| `forceops --help` (startup) | 9.6 ms ± 1.0 ms | 91.1 ms ± 3.8 ms | 9.5x |
| `forceops rm` (directory with 1,000 files) | 146.4 ms ± 4.1 ms | 201.3 ms ± 5.0 ms | 1.38x |

Steady-state delete throughput is identical between the two runtimes (BenchmarkDotNet, ratio 1.01-1.07) - AOT's win is startup time. Exe is 4.25 MB vs 4.36 MB for the 1.5.1 release exe.

<details>
<summary>Benchmark script</summary>

```powershell
# Build both flavours (from the repo root, on this branch)
dotnet publish ForceOps -c release -r win-x64   # Native AOT (PublishAot is set in the csproj)
dotnet build ForceOps -c release                # framework-dependent

$aot = "ForceOps/bin/release/net10.0/win-x64/publish/ForceOps.exe"
$fdd = "ForceOps/bin/release/net10.0/ForceOps.dll"

# Startup
hyperfine --warmup 5 "$aot --help" "dotnet $fdd --help"

# Delete a directory with 1,000 files
hyperfine --runs 30 --warmup 3 `
    --prepare 'pwsh -NoProfile -c "New-Item -ItemType Directory C:\Temp\fo-bench -Force | Out-Null; 1..1000 | ForEach-Object { Set-Content -Path C:\Temp\fo-bench\Note: installing/updating the tool now requires the .NET 10 SDK - older SDKs don't understand the pointer package. Little changes in practice: since #47 the tool already needs the .NET 10 runtime to run..txt -Value x }"' `
    "$aot rm C:\Temp\fo-bench" `
    "dotnet $fdd rm C:\Temp\fo-bench"
```

</details>

Note: installing/updating the tool now requires the .NET 10 SDK - older SDKs don't understand the pointer package. Little changes in practice: since #47 the tool already needs the .NET 10 runtime to run.


