### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 1.6.0
+* Update to .NET 10 in https://github.com/domsleee/ForceOps/pull/47
+* Package the dotnet tool as RID-specific Native AOT (win-x64), so `dotnet tool install` gets the fast-startup binary in https://github.com/domsleee/ForceOps/pull/49
+
 ## Release 1.5.1
 * Update dependencies and update to .net9 in https://github.com/domsleee/ForceOps/pull/44
 * Refactor CLI in https://github.com/domsleee/ForceOps/pull/45

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.5.1</Version>
+        <Version>1.6.0</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Version bump `1.5.1` -> `1.6.0` (Directory.Build.props + CHANGELOG).

Merge **after** #49 (the changelog references it). Squash-merge with a `chore(release):` title so the release workflow publishes.

If #48 also lands in 1.6.0, add its changelog line here first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
