### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Release 1.6.0
+* Update to .NET 10 in https://github.com/domsleee/ForceOps/pull/47
+* Update GitHub Actions for node24 deprecation in https://github.com/domsleee/ForceOps/pull/52
+* Update packages and migrate to System.CommandLine 2.0.9 stable in https://github.com/domsleee/ForceOps/pull/53
+
 ## Release 1.5.1
 * Update dependencies and update to .net9 in https://github.com/domsleee/ForceOps/pull/44
 * Refactor CLI in https://github.com/domsleee/ForceOps/pull/45

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.5.1</Version>
+        <Version>1.6.0</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
* Update to .NET 10
* Update GitHub Actions for node24 deprecation
* Update packages and migrate to System.CommandLine 2.0.9 stable