### PR TITLE
chore: update GitHub Actions for node24 deprecation

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -13,8 +13,8 @@ jobs:
   benchmark:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - name: Run benchmark
@@ -40,7 +40,7 @@ jobs:
           $modifiedContent = $fileContent -replace "``````", "```````n"
           $modifiedContent | Set-Content $fileName
       - name: Deploy Markdown Result
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ForceOps.Benchmarks/BenchmarkDotNet.Artifacts/results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,20 +18,21 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get version
         id: get_version
-        uses: KageKirin/get-csproj-version@v1.0.0
-        with:
-          file: Directory.Build.props
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version
+          "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Print Current Version
         run: |
           echo Current Version: ${{ steps.get_version.outputs.version }}
 
       - name: Install Dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -57,7 +58,7 @@ jobs:
 
       - name: Create release
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           name: "${{ steps.get_version.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,21 +20,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Get version
-        id: get_version
-        shell: pwsh
-        run: |
-          $version = ([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version
-          "version=$version" >> $env:GITHUB_OUTPUT
-
-      - name: Print Current Version
-        run: |
-          echo Current Version: ${{ steps.get_version.outputs.version }}
-
       - name: Install Dotnet
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
+
+      - name: Get version
+        id: get_version
+        shell: bash
+        run: echo "version=$(dotnet msbuild Directory.Build.props -getProperty:Version)" >> "$GITHUB_OUTPUT"
+
+      - name: Print Current Version
+        run: |
+          echo Current Version: ${{ steps.get_version.outputs.version }}
 
       - name: Directory structure
         run: |


### PR DESCRIPTION
* Bump actions ahead of the node24 forced default on June 16, 2026: `checkout` v4 -> v5, `setup-dotnet` v4 -> v5, `actions-gh-pages` v3 -> v4, `action-gh-release` v1 -> v2
* Replace `KageKirin/get-csproj-version@v1.0.0` (node20 + deprecated `set-output`) with `dotnet msbuild Directory.Build.props -getProperty:Version` — no third-party dependency, and MSBuild evaluates the version properly. The step now runs after `setup-dotnet` since `global.json` pins the SDK.