### PR TITLE
Benchmark NativeAOT alongside CoreCLR; add perf table to README

### DIFF
--- a/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
+++ b/ForceOps.Benchmarks/src/FileAndDirectoryDeleterBenchmark.cs
@@ -1,10 +1,11 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using ForceOps.Lib;
 
 namespace ForceOps.Benchmarks;
 
-// [SimpleJob(RuntimeMoniker.NativeAot80)]
-[SimpleJob]
+[SimpleJob(RuntimeMoniker.Net10_0, baseline: true)]
+[SimpleJob(RuntimeMoniker.NativeAot10_0)]
 public class FileAndDirectoryDeleterBenchmark
 {
 	readonly List<byte[]> fileDatas = new();

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ RelaunchHelpers.RunWithRelaunchAsElevated(() =>
 }, () => args.ToList(), forceOpsContext);
 ```
 
+## Performance
+
+Native AOT vs framework-dependent, measured with [hyperfine](https://github.com/sharkdp/hyperfine):
+
+| Scenario | Native AOT | Framework-dependent | Speedup |
+| --- | --- | --- | --- |
+| `forceops --help` (startup) | 9.8 ms ± 1.1 ms | 107.9 ms ± 6.9 ms | 11x |
+| `forceops rm` (directory with 1,000 files) | 151.4 ms ± 11.1 ms | 219.1 ms ± 15.8 ms | 1.45x |
+
+The scoop and GitHub release installs are Native AOT. `dotnet tool install` is framework-dependent.
+
 ## Context
 
 See [Benchmarks](https://domsleee.github.io/ForceOps/) on github pages.


### PR DESCRIPTION
* Revive the parked NativeAOT benchmark job (`[SimpleJob(RuntimeMoniker.NativeAot10_0)]`, possible now that BenchmarkDotNet 0.15.8 knows .NET 10); CoreCLR job is the baseline so the report includes a Ratio column
* Add a hyperfine startup/end-to-end table to the README (Native AOT 9.8 ms vs framework-dependent 107.9 ms startup)

Local run: steady-state delete throughput is identical between runtimes (ratio 1.01-1.07) - AOT''s win is startup only.

Notes:
* The benchmark workflow on main will now AOT-compile (~2 extra minutes) and the github-action-benchmark series names change (job name is part of the benchmark name), so the gh-pages chart starts new series
* The README line about `dotnet tool install` being framework-dependent should be updated when #49 (RID-specific AOT tool) merges