### PR TITLE
chore(release): 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Release 1.6.1
+* Package the dotnet tool as RID-specific Native AOT (win-x64) in https://github.com/domsleee/ForceOps/pull/49
+
 ## Release 1.6.0
 * Update to .NET 10 in https://github.com/domsleee/ForceOps/pull/47
 * Update GitHub Actions for node24 deprecation in https://github.com/domsleee/ForceOps/pull/52

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>By hook or by crook, perform operations on files and directories. If they are
             in use by a process, kill the process.</Description>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
         <PackageProjectUrl>https://github.com/domsleee/forceops</PackageProjectUrl>
         <RepositoryUrl>https://github.com/domsleee/forceops</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
* Package the dotnet tool as RID-specific Native AOT (win-x64)