### PR TITLE
fix: fail release workflow when a NuGet push fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,9 +66,7 @@ jobs:
           tag_name: "${{ steps.get_version.outputs.version }}"
 
       # RID-specific packages must be on the feed before the top-level pointer
-      # package. Separate steps so a failed RID push fails the job before the
-      # pointer is published (a multi-line pwsh step only reports the last
-      # command's exit code, which let the broken 1.6.1 release go green).
+      # package, so the pointer package is pushed in a second step.
       - name: Publish NuGet (RID packages)
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
         run: dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.win-x64.${{ steps.get_version.outputs.version }}.nupkg ForceOps/nupkg/ForceOps.any.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,12 +66,13 @@ jobs:
           tag_name: "${{ steps.get_version.outputs.version }}"
 
       # RID-specific packages must be on the feed before the top-level pointer
-      # package, so the pointer package is pushed in a second step.
-      # bash (-e) aborts on the first failed push; pwsh would run the next line
-      # anyway and report the step green even if the RID packages never made it.
-      - name: Publish NuGet
+      # package. Separate steps so a failed RID push fails the job before the
+      # pointer is published (a multi-line pwsh step only reports the last
+      # command's exit code, which let the broken 1.6.1 release go green).
+      - name: Publish NuGet (RID packages)
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
-        shell: bash
-        run: |
-          dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.win-x64.${{ steps.get_version.outputs.version }}.nupkg ForceOps/nupkg/ForceOps.any.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate
-          dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.${{ steps.get_version.outputs.version }}.nupkg --skip-duplicate
+        run: dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.win-x64.${{ steps.get_version.outputs.version }}.nupkg ForceOps/nupkg/ForceOps.any.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate
+
+      - name: Publish NuGet (pointer package)
+        if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
+        run: dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.${{ steps.get_version.outputs.version }}.nupkg --skip-duplicate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,8 +67,11 @@ jobs:
 
       # RID-specific packages must be on the feed before the top-level pointer
       # package, so the pointer package is pushed in a second step.
+      # bash (-e) aborts on the first failed push; pwsh would run the next line
+      # anyway and report the step green even if the RID packages never made it.
       - name: Publish NuGet
         if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(release)') }}
+        shell: bash
         run: |
           dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.win-x64.${{ steps.get_version.outputs.version }}.nupkg ForceOps/nupkg/ForceOps.any.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.nupkg ForceOps.Lib/nupkg/ForceOps.Lib.${{ steps.get_version.outputs.version }}.snupkg --skip-duplicate
           dotnet nuget push -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json ForceOps/nupkg/ForceOps.${{ steps.get_version.outputs.version }}.nupkg --skip-duplicate


### PR DESCRIPTION
## Problem

`dotnet tool install -g forceops` failed with:

> Version 1.6.1 of package forceops.win-x64 is not found in NuGet feeds

In the 1.6.1 release run, the push of the RID packages failed with 403 (the API keys package glob did not cover the new `ForceOps.win-x64`/`ForceOps.any` IDs introduced by #49). Because the publish step was multi-line pwsh — which only reports the **last** commands exit code — the failure did not stop the step: the next line pushed the top-level `ForceOps` pointer package and the run went green. Result: a live pointer package referencing packages that did not exist on the feed.

(The key glob has since been fixed to `ForceOps*` and the 1.6.1 run re-run, which repaired the feed.)

## Fix

Split the publish into two single-command steps. A step with one native command propagates its exit code even under pwsh, and the step boundary enforces the required ordering directly: a failed RID push fails the job before the pointer package is ever published. `--skip-duplicate` keeps re-runs safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)